### PR TITLE
Bug fix with ordinal loading in remote processes

### DIFF
--- a/Invoke-ReflectivePEInjection/Invoke-ReflectivePEInjection.ps1
+++ b/Invoke-ReflectivePEInjection/Invoke-ReflectivePEInjection.ps1
@@ -33,7 +33,7 @@ Author: Joe Bialek, Twitter: @JosephBialek
 License: BSD 3-Clause
 Required Dependencies: None
 Optional Dependencies: None
-Version: 1.2
+Version: 1.3
 
 .DESCRIPTION
 


### PR DESCRIPTION
When performing remote loading of a DLL that had imports using ordinals, the code would crash prompting that NumBytesWritten was undefined. NumBytesWritten is properly defined in the logical case that a name is used but not an ordinal (line 1327). Added a definition of NumBytesWritten directly above the place where the error was occurring which then fixed the bug. 
![screen shot 2014-12-28 at 4 04 45 pm](https://cloud.githubusercontent.com/assets/1566315/5564975/37aedec0-8eab-11e4-8275-5eac10b9f67a.png)
